### PR TITLE
[WIP] Use RxJS for Component loading & aborting

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     ]
   },
   "dependencies": {
-    "lodash.curry": "^4.1.1",
-    "lodash.curryright": "^4.1.1"
+    "lodash.curry": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,17 @@
     "react-test-renderer": "^15.4.2"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "rxjs": "^5.2.0"
   },
   "lint-staged": {
     "*.js": [
       "prettier --write",
       "git add"
     ]
+  },
+  "dependencies": {
+    "lodash.curry": "^4.1.1",
+    "lodash.curryright": "^4.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,6 @@ export default function Loadable(
     loadComponent() {
       this._componentWillUnmount$ = new Subject().take(1);
       const setState$ = Observable.bindCallback((err, Component, callback) => {
-        console.log(err, Component);
         this.setState(
           {
             isLoading: false,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import curryRight from "lodash.curryright";
 import curry from "lodash.curry";
 import { Observable } from "rxjs/Observable";
 import { Subject } from "rxjs/Subject";
@@ -59,7 +58,7 @@ export default function Loadable(
         .mergeMap(curry(setState$)(null))
         .timeout(delay)
         .takeUntil(this._componentWillUnmount$)
-        .catch(curryRight(setState$)(null))
+        .catch(curry(setState$)(curry.placeholder, null))
         .subscribe(
           () => this._componentWillUnmount$.next(),
           () => this._componentWillUnmount$.next()


### PR DESCRIPTION
By using a more Reactive Programming approach we can teardown our loader subscription & reduce any un-needed cpu overhead for components that have unmounted prior to fully loading.

An example of such a use-case would be in a chat client w/ some form of scroll virtualization. Where as the user scrolls up rapidly message-specific components may unmount before fully having the chance to load.

Another addition I'm thinking may be handy would be a way of tracking what components are already loading (LRU + Subjects?) so that duplicate components do not start two loaders in parallel.