### PR TITLE
Rework API, add preload()

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,3 +5,4 @@
 [libs]
 
 [options]
+suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore

--- a/README.md
+++ b/README.md
@@ -13,17 +13,30 @@ A higher order component for loading components with promises.
 ### Example
 
 ```js
+// @flow
 import path from 'path';
 import React from 'react';
 import Loadable from 'react-loadable';
 
-import MyLoadingComponent from './MyLoadingComponent';
-import MyErrorComponent from './MyErrorComponent';
+type Props = {
+  isLoading: boolean,
+  error: Error | null,
+  pastDelay: null,
+};
 
-const LoadableMyComponent = Loadable(
+let MyLoadingComponent = ({isLoading, error, pastDelay}: Props) => {
+  if (isLoading) {
+    return pastDelay ? <div>Loading...</div> : null; // Don't flash "Loading..." when we don't need to.
+  } else if (error) {
+    return <div>Error! Component failed to load</div>;
+  } else {
+    return null;
+  }
+};
+
+let LoadableMyComponent = Loadable(
   () => import('./MyComponent'),
   MyLoadingComponent,
-  MyErrorComponent,
   200,
   path.join(__dirname, './MyComponent')
 );
@@ -41,7 +54,6 @@ export default class Application extends React.Component {
 Loader(
   loader: () => Promise<React.Component>,
   LoadingComponent: React.Component,
-  ErrorComponent?: React.Component | null,
   delay?: number = 200,
   serverSideRequirePath?: string
 )
@@ -56,13 +68,26 @@ component.
 
 #### `LoadingComponent`
 
-React component displayed after `delay` until `loader()` succeeds or errors.
+React component displayed after `delay` until `loader()` succeeds. Also
+responsible for displaying errors.
 
-#### `MyErrorComponent` (optional, defaults to `null`)
+```js
+type Props = {
+  isLoading: boolean,
+  error: Error | null,
+  pastDelay: null,
+};  
 
-React component displayed after `delay` until `loader()` errors.
-
-Receives `error` prop with the promise rejection error.
+let MyLoadingComponent = ({isLoading, error, pastDelay}: Props) => {
+  if (isLoading) {
+    return pastDelay ? <div>Loading...</div> : null; // Don't flash "Loading..." when we don't need to.
+  } else if (error) {
+    return <div>Error! Component failed to load</div>;
+  } else {
+    return null;
+  }
+};
+```
 
 #### `delay` (optional, defaults to `200`, in milliseconds)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ export default class Application extends React.Component {
 ### API
 
 ```js
-Loader(
+Loadable(
   loader: () => Promise<React.Component>,
   LoadingComponent: React.Component,
   delay?: number = 200,
@@ -98,3 +98,41 @@ succeed or error.
 
 When rendering server-side, `require()` this path to load the component
 instead, this way it happens synchronously.
+
+#### `Loadable.preload()`
+
+The generated component has a static method `preload()` for calling the loader
+function ahead of time. This is useful for scenarios where you think the user
+might do something next and want to load the next component eagerly.
+
+**Example:**
+
+```js
+let LoadableMyComponent = Loadable(
+  () => import('./MyComponent'),
+  MyLoadingComponent,
+);
+
+class Application extends React.Component {
+  state = { showComponent: false };
+
+  onClick = () => {
+    this.setState({ showComponent: true });
+  };
+
+  onMouseOver = () => {
+    LoadableMyComponent.preload();
+  };
+
+  render() {
+    return (
+      <div>
+        <button onClick={this.onClick} onMouseOver={this.onMouseOver}>
+          Show loadable component
+        </button>
+        {this.state.showComponent && <LoadableMyComponent/>}
+      </div>
+    )
+  }
+}
+```

--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -1,46 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loading error 1`] = `null`;
+exports[`loading error 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"error":null}
+</div>
+`;
 
 exports[`loading error 2`] = `
 <div>
-  LoadingComponent
-   
-  {}
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
 exports[`loading error 3`] = `
 <div>
-  ErrorComponent
-   
-  {"error":{}}
+  MyLoadingComponent 
+  {"isLoading":false,"pastDelay":false,"error":{}}
 </div>
 `;
 
-exports[`loading success 1`] = `null`;
+exports[`loading success 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"error":null}
+</div>
+`;
 
 exports[`loading success 2`] = `
 <div>
-  LoadingComponent
-   
-  {}
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
 exports[`loading success 3`] = `
 <div>
-  LoadingComponent
-   
+  MyComponent 
   {"prop":"foo"}
 </div>
 `;
 
 exports[`loading success 4`] = `
 <div>
-  LoadingComponent
-   
+  MyComponent 
   {"prop":"bar"}
+</div>
+`;
+
+exports[`preload success 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"error":null}
+</div>
+`;
+
+exports[`preload success 2`] = `
+<div>
+  MyComponent 
+  {"prop":"baz"}
+</div>
+`;
+
+exports[`preload success 3`] = `
+<div>
+  MyComponent 
+  {"prop":"baz"}
 </div>
 `;
 


### PR DESCRIPTION
This changes the API so that a single "LoadingComponent" is responsible for loading and error states.

Also adds a `preload()` static method to the generated component.