### PR TITLE
NPM module fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-loadable",
   "version": "2.0.1",
   "description": "A higher order component for loading components with promises",
-  "main": "index.js",
+  "main": "lib/index.js",
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Currently, the `npm install`ed module doesn't work for two reasons:

1. absence of `lib`
2. `main` key in `package.json` points to `index.js` whereas it should point to `lib/index.js`

PR fixes the issue.