### PR TITLE
Propagate syntax error from server side rendering require

### DIFF
--- a/__fixtures__/component-with-syntax-error.js
+++ b/__fixtures__/component-with-syntax-error.js
@@ -1,0 +1,4 @@
+// Intentional type in function
+export default funtion Component() {
+  return <div />;
+}

--- a/__tests__/Loadable.test.js
+++ b/__tests__/Loadable.test.js
@@ -106,3 +106,20 @@ test("preload", async () => {
   let component2 = renderer.create(<LoadableMyComponent prop="baz" />);
   expect(component2.toJSON()).toMatchSnapshot(); // success
 });
+
+test("syntax error serverside", async () => {
+  let LoadableMyComponent = Loadable({
+    loader: async () => createLoader(400, null, new Error("test error")),
+    LoadingComponent: MyLoadingComponent,
+    serverSideRequirePath: path.join(
+      __dirname,
+      "../__fixtures__/component-with-syntax-error.js"
+    )
+  });
+
+  let component = renderer.create(<LoadableMyComponent />);
+
+  await waitFor(200);
+
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -81,3 +81,10 @@ exports[`server side rendering es6 1`] = `
   fixture2
 </div>
 `;
+
+exports[`syntax error serverside 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":false,"pastDelay":false,"error":{"pos":55,"loc":{"line":2,"column":23},"_babel":true,"codeFrame":"\\u001b[0m \\u001b[90m 1 | \\u001b[39m\\u001b[90m// Intentional type in function\\u001b[39m\\n\\u001b[31m\\u001b[1m&gt;\\u001b[22m\\u001b[39m\\u001b[90m 2 | \\u001b[39m\\u001b[36mexport\\u001b[39m \\u001b[36mdefault\\u001b[39m funtion \\u001b[33mComponent\\u001b[39m() {\\n \\u001b[90m   | \\u001b[39m                       \\u001b[31m\\u001b[1m^\\u001b[22m\\u001b[39m\\n \\u001b[90m 3 | \\u001b[39m  \\u001b[36mreturn\\u001b[39m \\u001b[33m&lt;\\u001b[39m\\u001b[33mdiv\\u001b[39m \\u001b[33m/\\u001b[39m\\u001b[33m&gt;\\u001b[39m\\u001b[33m;\\u001b[39m\\n \\u001b[90m 4 | \\u001b[39m}\\n \\u001b[90m 5 | \\u001b[39m\\u001b[0m"}}
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -31,8 +31,15 @@
     "react": "*"
   },
   "lint-staged": {
-    "*.js": [
+    "src/*.js": [
       "prettier --write",
+      "git add"
+    ],
+    "__tests__/*.js": [
+      "prettier --write",
+      "git add"
+    ],
+    "__fixtures__/*.js": [
       "git add"
     ]
   }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,11 @@ let tryRequire = (pathOrId: string | number) => {
   try {
     // $FlowIgnore
     return babelInterop(require(pathOrId));
-  } catch (err) {}
+  } catch (error) {
+    if (error.name === "SyntaxError") {
+      throw error;
+    }
+  }
   return null;
 };
 
@@ -43,11 +47,21 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
   let outsideError = null;
 
   if (serverSideRequirePath) {
-    outsideComponent = tryRequire(serverSideRequirePath);
+    try {
+      outsideComponent = tryRequire(serverSideRequirePath);
+    } catch (error) {
+      isLoading = false;
+      outsideError = error;
+    }
   }
 
   if (isWebpack && webpackRequireWeakId) {
-    outsideComponent = tryRequire(webpackRequireWeakId());
+    try {
+      outsideComponent = tryRequire(webpackRequireWeakId());
+    } catch (error) {
+      isLoading = false;
+      outsideError = error;
+    }
   }
 
   let load = () => {


### PR DESCRIPTION
Thanks for making this library :v:

While trying to add server side rendering to a project after I started to use react-loadable, I ran into a problem where it turned out that I tried to require an image and node wasn't to happy about that. I figured it would be a bit easier to catch if these errors were propagated to the error prop of the loading component. This is a PR trying to implement that.