### PR TITLE
fix webpack integration

### DIFF
--- a/flow-typed/webpack.js
+++ b/flow-typed/webpack.js
@@ -1,0 +1,2 @@
+declare function __webpack_require__(pathOrId: string | number): any;
+declare var __webpack_modules__: {};


### PR DESCRIPTION
❗️ This is actually a much bigger deal than originally thought. Check out [this repo](https://github.com/kentcdodds/react-loadable-webpack-bug) for more info. Here's the README (saved you a click):

---

This demonstrates a bug in the way that react-loadable intracts with webpack. If you pop open the `index.js` you'll see it's simply importing `react-loadable`. Check out the `bundle.js` file (which is generated by webpack) and you'll see some interesting things in there:

1. [`webpackEmptyContext`](https://github.com/kentcdodds/react-loadable-webpack-bug/blob/b2e7226491d17426f96e7f97d81d3566a154732a/bundle.js#L232-L244) - a module that webpack makes when you do `require(somethingDynamic)`.
2. [`require` replaced by IIFE that throws](https://github.com/kentcdodds/react-loadable-webpack-bug/blob/b2e7226491d17426f96e7f97d81d3566a154732a/bundle.js#L104)

**So, basically, the try/catch there will _always_ result in a throw with an ignored catch.**

Now, if you look at [this commit](https://github.com/kentcdodds/react-loadable-webpack-bug/commit/15898ccf8027993a40efc81fa9c72395f1a56525), it uses [my branch of react-loadable](https://github.com/kentcdodds/react-loadable/tree/pr/remove-webpack-warning) instead and the problem is fixed. Now:

1. `webpackEmptyContext` is replaced by a [`module` polyfill](https://github.com/kentcdodds/react-loadable-webpack-bug/blob/15898ccf8027993a40efc81fa9c72395f1a56525/bundle.js#L233-L260) (to account for `module.require`). This is actually dead code because `module.require` will never be used when running this with webpack anyway. :shrug:
2. `require` is now `requireFn` which will be assigned to `__webpack_require__` when running with webpack and simply `module.require` when running in node.

I've verified that my fix works wonderfully in my app. :) 

---

This uses `__webpack_require__` if `isWebpack` is true and `module.require` if not. This should work in both node and when bundled with webpack without causing issues.

Closes #10