### PR TITLE
expose promise in preload function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
     _mounted: boolean;
 
     static preload() {
-      load();
+      return load();
     }
 
     state = {


### PR DESCRIPTION
It is surprising this preload function is not returning promise from `load`. This way we could trigger custom logic after preloading finished.