### PR TITLE
Please enable issues / make LoadingComponent optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Function returning promise returning a React component displayed on success.
 Resulting React component receives all the props passed to the generated
 component.
 
-#### `opts.LoadingComponent`
+#### `opts.LoadingComponent` (optional, defaults to null)
 
 React component displayed after `delay` until `loader()` succeeds. Also
 responsible for displaying errors.

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
       let { pastDelay, error, Component } = this.state;
 
       if (isLoading || error) {
-        return (
+        return (!LoadingComponent ? null :
           <LoadingComponent
             isLoading={isLoading}
             pastDelay={pastDelay}


### PR DESCRIPTION
@thejameskyle 
Why is issues disabled? Please enable issues so people can report issues to you.

Additionally, the issue I am trying to raise: LoadingComponent should be optional, and default to null (nothing displayed).

This module currently throws errors when it's not supplied.