### PR TITLE
Return the promise from load to preload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
     _mounted: boolean;
 
     static preload() {
-      load();
+      return load();
     }
 
     state = {


### PR DESCRIPTION
So that one can preload multiple components and wait until all of them are done with Promise.all()