### PR TITLE
Move webpack require to component lifecycle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,17 +47,6 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
     outsideComponent = tryRequire(serverSideRequirePath);
   }
 
-  if (isWebpack && webpackRequireWeakId) {
-    let weakId = webpackRequireWeakId();
-    if (__webpack_modules__[weakId]) {
-      // if it's not in webpack modules, we wont be able
-      // to load it. If we attempt to, we mess up webpack's
-      // internal state, so only tryRequire if it's already
-      // in webpack modules.
-      outsideComponent = tryRequire(weakId);
-    }
-  }
-
   let load = () => {
     if (!outsidePromise) {
       isLoading = true;
@@ -82,11 +71,26 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
       load();
     }
 
-    state = {
-      error: outsideError,
-      pastDelay: false,
-      Component: outsideComponent
-    };
+    constructor(props) {
+      super(props);
+
+      if (isWebpack && webpackRequireWeakId) {
+        let weakId = webpackRequireWeakId();
+        if (__webpack_modules__[weakId]) {
+          // if it's not in webpack modules, we wont be able
+          // to load it. If we attempt to, we mess up webpack's
+          // internal state, so only tryRequire if it's already
+          // in webpack modules.
+          outsideComponent = tryRequire(weakId);
+        }
+      }
+
+      this.state = {
+        error: outsideError,
+        pastDelay: false,
+        Component: outsideComponent
+      };
+    }
 
     componentWillMount() {
       this._mounted = true;

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
     constructor(props) {
       super(props);
 
-      if (isWebpack && webpackRequireWeakId) {
+      if (!outsideComponent && isWebpack && webpackRequireWeakId) {
         let weakId = webpackRequireWeakId();
         if (__webpack_modules__[weakId]) {
           // if it's not in webpack modules, we wont be able


### PR DESCRIPTION
I'm proposing to move the initial Webpack require from the HoC closure -> the HoC constructor to allow markup from SSR apps to be reused by preloading Webpack Chunks.

i.e.

```
// index.html
<script src="/main.js"></script>
<script src="/chunk.0.js"></script>
<script>
    window.render(); // Exposed by main.js to allow us to wait for chunk 0 to load before rendering.
</script>
```

Without this change the Loadable HoC would be called as soon as main.js is parsed and executed meaning chunk 0 won't have executed yet.

Tbh, this change wouldn't be necessary if Webpack allowed you to load chunks before main, perhaps by registering themselves on the global and having the main chunk read them in when it has loaded, but I don't *think* Webpack supports this.

Also, if you're interested in merging this I can add tests.