### PR TITLE
Strawman: babel-plugin-transform-react-loadable

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ directly because that would add it to the bundle in Webpack or Browserify.
 For `webpackRequireWeakId` it needs to be a function because
 `require.resolveWeak` does not exist in any tool other than Webpack.
 
+If you use Babel, check out [babel-plugin-transform-react-loadable](https://github.com/motiz88/babel-plugin-transform-react-loadable) for a more automated way of setting these properties wherever you use `Loadable()`.
+
 #### How do I avoid repetition?
 
 Specifying the same `LoadingComponent` or `delay` every time you use


### PR DESCRIPTION
Hey there,

I made [babel-plugin-transform-react-loadable](https://github.com/motiz88/babel-plugin-transform-react-loadable) following [this random thought I had](https://twitter.com/motiz88/status/847215130429587457).

Weirdly enough, I don't actually have `react-loadable` set up in any of my projects at the moment. But I hadn't written a Babel plugin in a while, and the idea seemed valid enough, so I figured, what the heck. So this is me sharing it super early, but hopefully in a rather complete state, unless more rigorous testing shows otherwise.

I welcome any feedback, especially if anyone actually uses the plugin and has anything to report. The actual PR here is fairly minimal and should probably only be merged after it's rewritten and after we have evidence that this works in a real-world project.