### PR TITLE
Fix for preload() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,18 @@ let LoadableMyComponent = Loadable({
 });
 
 class Application extends React.Component {
-  state = { showComponent: false };
+  state = { showComponent: false, isLoadedComponent: false };
 
   onClick = () => {
     this.setState({ showComponent: true });
   };
 
   onMouseOver = () => {
-    LoadableMyComponent.preload();
+    const { isLoadedComponent } = this.state;
+    if (!isLoadedComponent) {
+      LoadableMyComponent.preload();
+      this.setState({ isLoadedComponent: true });
+    }
   };
 
   render() {


### PR DESCRIPTION
If we don't monitor if the component has been loaded then the component will load each time the button is hovered over.