### PR TITLE
pass props to loader

### DIFF
--- a/__tests__/Loadable.test.js
+++ b/__tests__/Loadable.test.js
@@ -120,3 +120,39 @@ test("resolveModule", async () => {
   await waitFor(200);
   expect(component.toJSON()).toMatchSnapshot(); // errored
 });
+
+let createPropsErrorLoader = delay => {
+  return async props => {
+    await waitFor(delay);
+    //console.log(props);
+    throw new Error(props.customerror);
+  };
+};
+
+let MyErrorComponent = ({ error }) => {
+  if (error) {
+    //console.error(error.message);
+    return (
+      <div>
+        MyErrorComponent
+        {error.message}
+      </div>
+    );
+  } else {
+    return <div>MyErrorComponent</div>;
+  }
+};
+
+test("loader props", async () => {
+  let LoadableMyComponent = Loadable({
+    loader: createPropsErrorLoader(300),
+    LoadingComponent: MyErrorComponent
+  });
+
+  let component = renderer.create(
+    <LoadableMyComponent customerror="dolphin" />
+  );
+  expect(component.toJSON()).toMatchSnapshot();
+  await waitFor(400);
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -21,6 +21,19 @@ exports[`loading error 3`] = `
 </div>
 `;
 
+exports[`loader props 1`] = `
+<div>
+  MyErrorComponent
+</div>
+`;
+
+exports[`loader props 2`] = `
+<div>
+  MyErrorComponent
+  dolphin
+</div>
+`;
+
 exports[`loading success 1`] = `
 <div>
   MyLoadingComponent 

--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,10 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
     outsideComponent = tryRequire(serverSideRequirePath);
   }
 
-  let load = () => {
+  let load = props => {
     if (!outsidePromise) {
       isLoading = true;
-      outsidePromise = loader()
+      outsidePromise = loader(props)
         .then(Component => {
           isLoading = false;
           outsideComponent = resolveModuleFn(Component);
@@ -69,7 +69,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
     _mounted: boolean;
 
     static preload() {
-      load();
+      load(this.props);
     }
 
     constructor(props) {
@@ -107,7 +107,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options) {
         delay
       );
 
-      load().then(() => {
+      load(this.props).then(() => {
         if (!this._mounted) return;
         clearTimeout(this._timeout);
         this.setState({


### PR DESCRIPTION
Hi,

Thoughts on passing component props into the loader() method?

Ideally want to be be able to do something like this:

```
let Layout = Loadable({
    loader: (props) => {
        return Promise.all([
            System.import('./LayoutAsync'),
            System.import('./../logic/section1')
        ]).then(function([component, module]) {
            injectReducer(props.contextstore, {key: 'section1State', reducer: module.reducer});
            return component;
        })
    },
});
```

Thought could do stuff such as loading language specific resources