### PR TITLE
add support for HMR, flushWebpackRequireWeakIds test, new flushRequires method

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ let weakIdsOrRequirePaths = flushRequires();
 // ["/path/to/component.js", "/path/to/other/component.js"]
 // or
 // [1, 2]
-// depending on the environment (Webpack vs. Babel)
+// depending on the environment (Babel vs. Webpack)
 ```
 
 > **Note:** These are flushed individually, one does not affect the other.

--- a/__fixtures__/stats.js
+++ b/__fixtures__/stats.js
@@ -1,0 +1,46 @@
+export const stats = {
+  assetsByChunkName: {
+    bootstrap: ["bootstrap.js", "bootstrap.no_css.js"],
+    vendor: ["vendor.js", "vendor.no_css.js"],
+    main: ["main.js", "main.no_css.js", "main.css"]
+  },
+  chunks: [
+    {
+      id: 0,
+      files: ["0.js", "0.no_css.js", "0.css"]
+    },
+    {
+      id: 1,
+      files: ["1.js", "1.no_css.js", "1.css"]
+    }
+    // chunk with id: 2 intentionally missing to test against invalid stats
+  ],
+  modules: [
+    {
+      id: "qwer",
+      name: "./src/Components/Example.js",
+      chunks: [0]
+    },
+    {
+      id: "asdf",
+      name: "./src/Components/Foo.js",
+      chunks: [1]
+    },
+    {
+      id: "zxcv",
+      name: "./src/Components/Bar.js",
+      chunks: [2]
+    }
+  ],
+  publicPath: "/static/"
+};
+
+export const babelFilePaths = [
+  "./src/Components/Example.js",
+  "./src/Components/Foo.js",
+  "./src/Components/Bar.js"
+];
+
+export const webpackModuleIds = ["qwer", "asdf", "zxcv"];
+
+export const rootDir = "/Users/jamesgillmore/App";

--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`babel: server side rendering flushing 1`] = `
+Array [
+  "/component.js",
+  "/component2.js",
+]
+`;
+
+exports[`babel: server side rendering flushing 2`] = `
+Array [
+  "/component.js",
+  "/component3.js",
+]
+`;
+
 exports[`loading error 1`] = `
 <div>
   MyLoadingComponent 
@@ -103,16 +117,16 @@ exports[`server side rendering es6 1`] = `
 </div>
 `;
 
-exports[`server side rendering flushing 1`] = `
+exports[`webpack: server side rendering flushing 1`] = `
 Array [
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component.js",
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component2.js",
+  "/component.js",
+  "/component2.js",
 ]
 `;
 
-exports[`server side rendering flushing 2`] = `
+exports[`webpack: server side rendering flushing 2`] = `
 Array [
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component.js",
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component3.js",
+  "/component.js",
+  "/component3.js",
 ]
 `;

--- a/__tests__/__snapshots__/flushFiles.test.js.snap
+++ b/__tests__/__snapshots__/flushFiles.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createFilesByModuleId() 1`] = `
+Object {
+  "asdf": Array [
+    "1.js",
+    "1.no_css.js",
+    "1.css",
+  ],
+  "qwer": Array [
+    "0.js",
+    "0.no_css.js",
+    "0.css",
+  ],
+  "zxcv": Array [],
+}
+`;
+
+exports[`createFilesByPath() 1`] = `
+Object {
+  "./src/Components/Bar.js": Array [],
+  "./src/Components/Example.js": Array [
+    "0.js",
+    "0.no_css.js",
+    "0.css",
+  ],
+  "./src/Components/Foo.js": Array [
+    "1.js",
+    "1.no_css.js",
+    "1.css",
+  ],
+}
+`;
+
+exports[`flush() called as pure function babel: uses default entries when no named chunks provided via opts.before/after 1`] = `
+Array [
+  "0.js",
+  "0.no_css.js",
+  "0.css",
+  "1.js",
+  "1.no_css.js",
+  "1.css",
+]
+`;
+
+exports[`flush() called as pure function webpack: uses default entries when no named chunks provided via opts.before/after 1`] = `
+Array [
+  "0.js",
+  "0.no_css.js",
+  "0.css",
+  "1.js",
+  "1.no_css.js",
+  "1.css",
+]
+`;

--- a/__tests__/flushFiles.test.js
+++ b/__tests__/flushFiles.test.js
@@ -1,0 +1,108 @@
+// @noflow
+import {
+  flush,
+  flushBabel,
+  flushWebpack,
+  createFilesByPath,
+  createFilesByModuleId,
+  isUnique,
+  normalizePath,
+  concatFilesAtKeys
+} from "../src/flushFiles";
+
+import {
+  stats,
+  rootDir,
+  babelFilePaths,
+  webpackModuleIds
+} from "../__fixtures__/stats";
+
+/** FLUSH */
+
+describe("flush() called as pure function", () => {
+  it("babel: uses default entries when no named chunks provided via opts.before/after", () => {
+    const files = flush(babelFilePaths, stats, false, rootDir); /*? */
+    expect(files).toMatchSnapshot();
+  });
+
+  it("webpack: uses default entries when no named chunks provided via opts.before/after", () => {
+    const files = flush(webpackModuleIds, stats, true, undefined); /*? */
+    expect(files).toMatchSnapshot();
+  });
+});
+
+/** BABEL VS. WEBPACK FLUSHING */
+
+test("flushBabel()", () => {
+  const files = flushBabel(babelFilePaths, stats, rootDir); /*? */
+  const allFiles = stats.chunks[0].files.concat(stats.chunks[1].files);
+  expect(files).toEqual(allFiles);
+});
+
+test("flushWebpack()", () => {
+  const files = flushWebpack(webpackModuleIds, stats); /*? */
+  const allFiles = stats.chunks[0].files.concat(stats.chunks[1].files);
+  expect(files).toEqual(allFiles);
+});
+
+test("flushBabel() throws with no rootDir argument", () => {
+  const flush = () => flushBabel(babelFilePaths, stats); /*? */
+  expect(flush).toThrow();
+});
+
+/** CREATE FILES MAP */
+
+test("createFilesByPath()", () => {
+  const filesByPath = createFilesByPath(stats); /*? */
+
+  expect(Object.keys(filesByPath)).toEqual(babelFilePaths);
+
+  expect(filesByPath["./src/Components/Example.js"]).toEqual([
+    "0.js",
+    "0.no_css.js",
+    "0.css"
+  ]);
+  expect(filesByPath["./src/Components/Bar.js"]).toEqual([]); // test against arrays of undefined
+
+  expect(filesByPath).toMatchSnapshot();
+});
+
+test("createFilesByModuleId()", () => {
+  const filesByPath = createFilesByModuleId(stats); /*? */
+
+  expect(Object.keys(filesByPath)).toEqual(webpackModuleIds);
+
+  expect(filesByPath.qwer).toEqual(["0.js", "0.no_css.js", "0.css"]);
+  expect(filesByPath.zxcv).toEqual([]); // test against arrays of undefined
+
+  expect(filesByPath).toMatchSnapshot();
+});
+
+/** HELPERS */
+
+test("isUnique()", () => {
+  let filtered = [1, 2, 2].filter(isUnique);
+  expect(filtered).toEqual([1, 2]);
+
+  filtered = [1, 2, 3].filter(isUnique);
+  expect(filtered).toEqual([1, 2, 3]);
+});
+
+test("normalizePath()", () => {
+  const path = "/Users/jamesgillmore/App/src/Components/Example.js";
+  const normalizedPath = normalizePath(path, rootDir);
+
+  expect(normalizedPath).toEqual("./src/Components/Example.js");
+});
+
+test("concatFilesAtKeys()", () => {
+  const filesMap = {
+    "./src/Components/Example.js": ["0.js", "0.css"],
+    "./src/Components/Foo.js": ["1.js", "1.css"],
+    "./src/Components/Bar.js": ["2.js", "2.css"]
+  };
+  const paths = ["./src/Components/Example.js", "./src/Components/Bar.js"];
+  const files = concatFilesAtKeys(filesMap, paths);
+
+  expect(files).toEqual(["0.js", "0.css", "2.js", "2.css"]);
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,3 @@
+module.exports = {
+  flushFiles: require("./lib/flushFiles.js")
+};

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
 module.exports = {
+  flushRequires: require("./lib/index.js").flushRequires,
   flushFiles: require("./lib/flushFiles.js")
 };

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
 module.exports = {
   flushRequires: require("./lib/index.js").flushRequires,
-  flushFiles: require("./lib/flushFiles.js")
+  flushFiles: require("./lib/flushFiles.js").default
 };

--- a/src/flushFiles.js
+++ b/src/flushFiles.js
@@ -1,0 +1,150 @@
+// @flow
+
+declare function __webpack_require__(pathOrId: string): any;
+
+type FilesMap = {
+  [key: string]: Array<string>
+};
+type Chunk = {
+  id: number,
+  files: Array<string>
+};
+type Module = {
+  id: string,
+  name: string,
+  chunks: Array<number>
+};
+type Stats = {
+  assetsByChunkName: FilesMap,
+  chunks: Array<Chunk>,
+  modules: Array<Module>,
+  publicPath: string
+};
+type Options = {
+  before?: Array<string>,
+  after?: Array<string>,
+  rootDir?: string,
+  outputPath?: string
+};
+
+// `flushChunks` depends on React Loadable producing module IDs as strings
+// via: NamedModulesPlugin or HashedModuleIdsPlugin:
+type Files = Array<string>;
+
+let filesByPath = null;
+let filesByModuleId = null;
+
+const IS_WEBPACK = typeof __webpack_require__ !== "undefined";
+const IS_TEST = process.env.NODE_ENV === "test"; // used to disable caching for tests
+
+/** PUBLIC API */
+
+export default (pathsOrIds: Files, stats: Stats, opts?: Options = {}): Files =>
+  flush(pathsOrIds, stats, IS_WEBPACK, opts.rootDir);
+
+/** BABEL VS. WEBPACK FLUSHING */
+
+const flush = (
+  pathsOrIds: Files,
+  stats: Stats,
+  isWebpack: boolean,
+  rootDir: ?string
+) =>
+  !isWebpack
+    ? flushBabel(pathsOrIds, stats, rootDir).filter(isUnique)
+    : flushWebpack(pathsOrIds, stats).filter(isUnique);
+
+const flushBabel = (paths: Files, stats: Stats, rootDir: ?string): Files => {
+  if (!rootDir) {
+    throw new Error(
+      `No \`rootDir\` was provided as an option to \`flushChunks\`.
+      Please provide one so modules rendered server-side can be
+      paired to their webpack equivalents client-side, and their
+      corresponding chunks.`
+    );
+  }
+
+  const dir = rootDir; // satisfy flow
+
+  filesByPath = filesByPath && !IS_TEST
+    ? filesByPath // cached
+    : createFilesByPath(stats);
+
+  return concatFilesAtKeys(filesByPath, paths.map(p => normalizePath(p, dir)));
+};
+
+const flushWebpack = (ids: Files, stats: Stats): Files => {
+  filesByModuleId = filesByModuleId && !IS_TEST
+    ? filesByModuleId // cached
+    : createFilesByModuleId(stats);
+
+  return concatFilesAtKeys(filesByModuleId, ids);
+};
+
+/** CREATE FILES MAP */
+
+const createFilesByPath = ({ chunks, modules }: Stats): FilesMap => {
+  const filesByChunk = chunks.reduce(
+    (chunks, chunk) => {
+      chunks[chunk.id] = chunk.files;
+      return chunks;
+    },
+    {}
+  );
+
+  return modules.reduce(
+    (filesByPath, module) => {
+      const filePath = module.name;
+      const files = concatFilesAtKeys(filesByChunk, module.chunks);
+
+      filesByPath[filePath] = files.filter(isUnique);
+      return filesByPath;
+    },
+    {}
+  );
+};
+
+const createFilesByModuleId = (stats: Stats): FilesMap => {
+  const filesByPath = createFilesByPath(stats);
+
+  return stats.modules.reduce(
+    (filesByModuleId, module) => {
+      const filePath = module.name;
+      const id = module.id;
+
+      filesByModuleId[id] = filesByPath[filePath];
+      return filesByModuleId;
+    },
+    {}
+  );
+};
+
+/** HELPERS */
+
+const isUnique = (v: string, i: number, self: Files): boolean =>
+  self.indexOf(v) === i;
+
+const normalizePath = (path: string, rootDir: string): string =>
+  `${path.replace(rootDir, ".").replace(/\.js$/, "")}.js`;
+
+const concatFilesAtKeys = (
+  inputFilesMap: FilesMap,
+  pathsOrIdsOrChunks: Array<any>
+): Files =>
+  pathsOrIdsOrChunks.reduce(
+    (files, key) => files.concat(inputFilesMap[key] || []),
+    []
+  );
+
+/** EXPORTS FOR TESTS */
+
+export {
+  flush,
+  flushBabel,
+  flushWebpack,
+  createFilesByPath,
+  createFilesByModuleId,
+  isUnique,
+  normalizePath,
+  concatFilesAtKeys
+};

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,27 @@
+module.exports = wallaby => {
+  process.env.NODE_ENV = "test";
+
+  return {
+    files: [
+      { pattern: "src/**/*.js", load: false },
+      { pattern: "package.json", load: false },
+      { pattern: "__tests__/**/*.snap", load: false },
+      { pattern: "__fixtures__/**/*.js", load: false }
+    ],
+
+    filesWithNoCoverageCalculated: ["__fixtures__/**/*.js"],
+
+    tests: ["__tests__/**/*.js"],
+
+    env: {
+      type: "node",
+      runner: "node"
+    },
+
+    testFramework: "jest",
+    compilers: {
+      "**/*.js": wallaby.compilers.babel({ babelrc: true })
+    },
+    debug: false
+  };
+};


### PR DESCRIPTION
This commit is a long time coming. This repo has the comments turned off, so I'm going to take a second to describe the journey to this point:

Originally my commit here had the code for comprehensive chunk flushing support, but then I realized it made the most sense to follow the Unix philosophy and create another package since the API boundaries were so clean. 

As a result, the following packages handle javascript and css chunk flushing by being passed the requires of `react-loadable`:

https://github.com/faceyspacey/webpack-flush-chunks
https://github.com/faceyspacey/extract-css-chunks-webpack-plugin

And here's a new boilerplate putting all 3 of these packages together:
https://github.com/faceyspacey/flush-chunks-boilerplate
*it works now, even without this PR. Give it a try!*

A LOT of work has gone into making those packages and the boilerplate feature-complete, tested and well-documented. This commit would have come several weeks ago, except handling CSS *(the creation of multiple css chunk files)* and support for css HMR ended up being quite the unanticipated trek. But I think the result is actually a solution that gives competing CSS solutions a run for their money. My notes on the matter are in the `extract-css-chunks-webpack-plugin` [readme](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin).

In general, every which scenario I could think of has been covered in `webpack-flush-chunks` and its corresponding boilerplate: babel building, universal webpack bundling, development, production, embedding your chunks as strings or React Components, embedding CSS instead of stylesheets, HMR, sending the smallest amount of CSS over the wire and more. As I said, I originally intended for the `webpack-flush-chunks` package to be part of React Loadable, but after you added the 2 flushing functions it just made the most sense to keep it separate, so that other packages can rely on it as well.

If you have the time, I'd love your feedback on the above tools. My hope is for them to become official companion tools to *React Loadable* for their given purposes.

...What was left after I removed the chunk flushing are the following things in this commit:

- support for HMR by storing the updated component in the closure rather than instance `state`
- the missing test for `flushWebpackRequireWeakIds()`
- a proposed `flushRequires` method which provides a clean API to perform module flushing regardless of the environment. It helps make documentation for using `webpack-flush-chunks` a bit easier to digest.
- and a `wallaby.js` file because that's central to my workflow and I'd like to provide any help you need in maintaining this package 💯  


