### PR TITLE
Add webpackChunkName option and update babel plugin

### DIFF
--- a/__tests__/Loadable.test.js
+++ b/__tests__/Loadable.test.js
@@ -3,7 +3,10 @@ declare var test: any;
 import path from "path";
 import React from "react";
 import renderer from "react-test-renderer";
-import Loadable, { flushServerSideRequirePaths } from "../src";
+import Loadable, {
+  flushServerSideRequirePaths,
+  flushWebpackChunkNames
+} from "../src";
 
 let waitFor = (delay: number) => {
   return new Promise(resolve => {

--- a/__tests__/__snapshots__/babel-plugin.test.js.snap
+++ b/__tests__/__snapshots__/babel-plugin.test.js.snap
@@ -37,6 +37,26 @@ let LoadableMyComponent = Loadable({
 });"
 `;
 
+exports[`add-webpack-chunk-name-property 1`] = `
+"import Loadable from \\"react-loadable\\";
+let LoadableMyComponent = Loadable({
+  loader: () => import(\\"./MyComponent\\" /* webpackChunkName: \\"my-component\\" */),
+  webpackChunkName: \\"my-component\\",
+  webpackRequireWeakId: () => require.resolveWeak(\\"./MyComponent\\"),
+  LoadingComponent: MyLoadingComponent
+});"
+`;
+
+exports[`add-webpack-chunk-name-property 2`] = `
+"import Loadable from \\"react-loadable\\";
+let LoadableMyComponent = Loadable({
+  loader: () => import( /*webpackChunkName: \\"my-component\\"*/\\"./MyComponent\\"),
+  webpackChunkName: \\"my-component\\",
+  webpackRequireWeakId: () => require.resolveWeak(\\"./MyComponent\\"),
+  LoadingComponent: MyLoadingComponent
+});"
+`;
+
 exports[`not-overwrite-existing-properties 1`] = `
 "import Loadable from \\"react-loadable\\";
 let LoadableMyComponent = Loadable({

--- a/__tests__/babel-plugin.test.js
+++ b/__tests__/babel-plugin.test.js
@@ -122,3 +122,37 @@ test("track-imports-correctly", () => {
     )
   ).toMatchSnapshot();
 });
+
+test("add-webpack-chunk-name-property", () => {
+  expect(
+    fn(
+      `
+    import Loadable from "react-loadable";
+    let LoadableMyComponent = Loadable({
+      loader: () => import("./MyComponent" /* webpackChunkName: "my-component" */ ),
+      LoadingComponent: MyLoadingComponent,
+    });
+  `,
+      {
+        server: false,
+        webpack: true
+      }
+    )
+  ).toMatchSnapshot();
+
+  expect(
+    fn(
+      `
+    import Loadable from "react-loadable";
+    let LoadableMyComponent = Loadable({
+      loader: () => import(/*webpackChunkName: "my-component"*/ "./MyComponent"),
+      LoadingComponent: MyLoadingComponent,
+    });
+  `,
+      {
+        server: false,
+        webpack: true
+      }
+    )
+  ).toMatchSnapshot();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ type LoadedComponent<Props> = GenericComponent<Props>;
 type LoadingComponent = GenericComponent<{}>;
 
 let SERVER_SIDE_REQUIRE_PATHS = new Set();
+let WEBPACK_CHUNK_NAMES = new Set();
 let WEBPACK_REQUIRE_WEAK_IDS = new Set();
 
 let isWebpack = typeof __webpack_require__ !== "undefined";
@@ -29,6 +30,7 @@ type Options<Props> = {
   LoadingComponent: LoadingComponent,
   delay?: number,
   serverSideRequirePath?: string,
+  webpackChunkName?: string,
   webpackRequireWeakId?: () => number,
   resolveModule?: (obj: Object) => LoadedComponent<Props>
 };
@@ -38,6 +40,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options<Props>) {
   let LoadingComponent = opts.LoadingComponent;
   let delay = opts.delay || 200;
   let serverSideRequirePath = opts.serverSideRequirePath;
+  let webpackChunkName = opts.webpackChunkName;
   let webpackRequireWeakId = opts.webpackRequireWeakId;
   let resolveModuleFn = opts.resolveModule ? opts.resolveModule : babelInterop;
 
@@ -129,8 +132,14 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options<Props>) {
     render() {
       let { pastDelay, error, Component } = this.state;
 
-      if (!isWebpack && serverSideRequirePath) {
-        SERVER_SIDE_REQUIRE_PATHS.add(serverSideRequirePath);
+      if (!isWebpack) {
+        if (serverSideRequirePath) {
+          SERVER_SIDE_REQUIRE_PATHS.add(serverSideRequirePath);
+        }
+
+        if (webpackChunkName) {
+          WEBPACK_CHUNK_NAMES.add(webpackChunkName);
+        }
       }
 
       if (isWebpack && webpackRequireWeakId) {
@@ -157,6 +166,12 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options<Props>) {
 export function flushServerSideRequirePaths() {
   let arr = Array.from(SERVER_SIDE_REQUIRE_PATHS);
   SERVER_SIDE_REQUIRE_PATHS.clear();
+  return arr;
+}
+
+export function flushWebpackChunkNames() {
+  let arr = Array.from(WEBPACK_CHUNK_NAMES);
+  WEBPACK_CHUNK_NAMES.clear();
   return arr;
 }
 


### PR DESCRIPTION
This builds on ideas from `flushServerSideRequirePaths` but focuses on chunks rather than file-system paths. 

By utilizing [`webpackChunkName`](https://webpack.js.org/guides/code-splitting-async/#chunk-names) alongside a new method `flushWebpackChunkNames`, you'll be able to generate list of chunks that were included in a server-side render. This can then be used with something like [`webpack-manifest-plugin`](https://github.com/danethurber/webpack-manifest-plugin) to map chunk names to chunk output filenames.

**LoadingComponent.js**

```js
const Page = withLoadable({
  loader: () => import('./MyComponent' /* webpackChunkName: "my-component" */),
});
```

**server.js**

```js
import { flushWebpackChunkNames } from 'react-loadable';

...
const manifest = require('./build/manifest.json');
const chunks = flushWebpackChunkNames().map(name => `/${name}.js`);
const scripts = chunks.map(path => manifest[path]);

renderToStaticMarkup(
  <html>
    <head>
      {scripts.map(src => <script src={src} />)}
    </head>
  </html>
);
```

It's possible to manually specify the chunk name using the `webpackChunkName` option as with `serverSideRequirePath`. The updated babel plugin includes generation of this property based on the comment contents.

I haven't updated the `README` yet incase you decide against this new feature or want to change it but I'd be more than happy update that as well.