### PR TITLE
WIP: Webpack server / fix for checksum issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## FORK of react-loadable
+
+Key differences:
+- Supports running webpack on server code.
+- Adds a flush for webpack chunk names.
+- Default loading component.
+
 # `react-loadable`
 
 A higher order component for loading components with promises.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-loadable",
-  "version": "3.3.1",
+  "name": "@humblespark/react-loadable",
+  "version": "3.4.1",
   "description": "A higher order component for loading components with promises",
   "main": "lib/index.js",
   "author": "James Kyle <me@thejameskyle.com>",


### PR DESCRIPTION
Awesome project!

PR not meant to be merged as is. Wanted to start a discussion re: webpack server & checksum mismatch

- I use webpack on server. Currently the `isWebpack` check returns false in webpack server env.
- There is a general issue with react checksum not matching on master. Server renders, but then client requests the JS, and empties dom.

This lets lets us flush our chunk names, so that we can load all the scripts we need before rendering client side.

```
const Component = Loadable({
  loader: () => import(/* webpackChunkName: "myComponent" */'myComponent'),
  webpackRequireWeakId: () => require.resolveWeak('myComponent'),
  chunkName: 'myComponent',
});
```

can play with it in my starter kit https://github.com/HumbleSpark/sambell - scoped this fork to `@humblespark/react-loadable`