### PR TITLE
Pass props destined for the component that is being loaded into `LoadingComponent` for interim display purposes

### DIFF
--- a/__tests__/Loadable.test.js
+++ b/__tests__/Loadable.test.js
@@ -126,7 +126,12 @@ test("server side rendering flushing", async () => {
     return Loadable({
       loader: createLoader(400, null, new Error("test error")),
       LoadingComponent: MyLoadingComponent,
-      serverSideRequirePath: path.join(__dirname, "..", "__fixtures__", name)
+      serverSideRequirePath: path.join(
+        path.basename(__dirname),
+        "..",
+        "__fixtures__",
+        name
+      )
     });
   };
 

--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -3,35 +3,35 @@
 exports[`loading error 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
 exports[`loading error 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
 exports[`loading error 3`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":false,"pastDelay":false,"error":{}}
+  {"prop":"baz","isLoading":false,"pastDelay":false,"error":{}}
 </div>
 `;
 
 exports[`loading success 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"foo","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
 exports[`loading success 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"error":null}
+  {"prop":"foo","isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
@@ -52,7 +52,7 @@ exports[`loading success 4`] = `
 exports[`preload 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
@@ -73,14 +73,14 @@ exports[`preload 3`] = `
 exports[`resolveModule 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
 exports[`resolveModule 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
@@ -105,14 +105,14 @@ exports[`server side rendering es6 1`] = `
 
 exports[`server side rendering flushing 1`] = `
 Array [
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component.js",
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component2.js",
+  "__fixtures__/component.js",
+  "__fixtures__/component2.js",
 ]
 `;
 
 exports[`server side rendering flushing 2`] = `
 Array [
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component.js",
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component3.js",
+  "__fixtures__/component.js",
+  "__fixtures__/component3.js",
 ]
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options<Props>) {
       if (isLoading || error) {
         return (
           <LoadingComponent
+            {...this.props}
             isLoading={isLoading}
             pastDelay={pastDelay}
             error={error}


### PR DESCRIPTION
Passing the `LoadableComponent`'s props into the `LoadingComponent` rather than just `isLoading/error/pastDelay` allows the `LoadingComponent` to be much smarter about what it can display.  

Rather than simply acting as a standard message or indicator (or having to create multiple LoadingComponents tailored for different scenarios), it could act as a generic placeholder, while still being able to show customised messaging, and take on the same dimensional or visual style properties etc albeit in a lightweight and generic interim component. 

This can aid the loading to feel much more seamless. 

As the `LoadingComponent` is passed by class reference to `Loadable` rather than a component instance, I cant think of any way to wrap the Loadable into another HOC that can affect such props within the LoadingComponent itself, based on those props that are destined for the final component?

For example, I cant see how another HOC could get the expansion props destined for the `MapCardContent` component to be usable by `CardContentLoading` component in the interim (The following was tested and works with the proposed change by the way)

```TypeScript
import * as React from 'react'
import Loadable, {LoadableComponent, LoadingComponentProps, LoadedComponent} from 'react-loadable'
import {CardContentExpander, CardContentExpanderProps} from '../../CardContentExpander/CardContentExpander'
import * as lazy from './MapCardContent'

export const CardContentLoading = (props: CardContentExpanderProps & LoadingComponentProps) =>
  <CardContentExpander expanded={props.expanded} gridSpanX={props.gridSpanX} gridSpanY={props.gridSpanY}>
    {props.isLoading && <span>Loading...</span>}
    {props.error && <span>ERROR</span>}
  </CardContentExpander>

type LazyProps = lazy.MapCardContentProps // (extends CardContentExpanderProps)
type LazyComponent = typeof lazy.MapCardContent

export default Loadable<LazyProps, LazyComponent>({
  loader: (): Promise<LazyComponent> => System.import<LazyComponent>(/* webpackChunkName: "map" */ './MapCardContent'),
  LoadingComponent: CardContentLoading
})
```

Also fixed issue with fixture paths in snapshots, as were failing if you were on a different machine to the previous run. Paths are now relative to the package root rather than the machine root