### PR TITLE
Parallel requests when importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ let LoadableMyComponent = Loadable({
   delay: 200,
   serverSideRequirePath: path.join(__dirname, './MyComponent'),
   webpackRequireWeakId: () => require.resolveWeak('./MyComponent'),
+  parallels: [fetch(), fetchNumber2()],
+  onLoaded: ([Component, result1, result2]) => {
+    // ... do what you want
+    return Promise.resolve(Component)
+  }
 });
 
 export default class Application extends React.Component {
@@ -72,6 +77,8 @@ Loadable({
   delay?: number = 200,
   serverSideRequirePath?: string,
   webpackRequireWeakId?: () => number,
+  parallels: Array<() => Promise>,
+  onLoaded: (Array<mixed>) => void,
 })
 ```
 
@@ -154,6 +161,34 @@ you can use this to function to resolve it.
 Loadable({
   // ...
   resolveModule: module => module.MyComponent
+});
+```
+
+#### `opts.parallels` (optional)
+
+If you need to make additional requests (assets, data, etc...) alongside your
+component, you can send them as an array of promise functions.
+
+```js
+Loadable({
+  // ...
+  parallels: [
+    () => new Promise((resolve, reject) => {
+      // ... do whatever you need
+    }),
+  ],
+});
+```
+
+#### `opts.onLoaded` (optional)
+
+This callback is called when the component (and its optional parallel requests)
+have finished loading. You need to return a resolved promised with the component.
+
+```js
+Loadable({
+  // ...
+  onLoaded: ([Component, ...optionalResults]) => Promise.resolve(Component),
 });
 ```
 

--- a/__tests__/Loadable.test.js
+++ b/__tests__/Loadable.test.js
@@ -148,3 +148,18 @@ test("server side rendering flushing", async () => {
   renderer.create(<App one={true} two={false} three={true} />);
   expect(flushServerSideRequirePaths()).toMatchSnapshot(); // serverside
 });
+
+test("parallels", async () => {
+  let LoadableMyComponent = Loadable({
+    loader: createLoader(200, MyComponent),
+    LoadingComponent: MyLoadingComponent,
+    parallels: [() => new Promise(resolve => resolve("foo"))],
+    onLoaded: ([Component, value1]) => {
+      expect(value1).toBe("foo");
+      return Promise.resolve(Component);
+    }
+  });
+
+  let component = renderer.create(<LoadableMyComponent />);
+  expect(component.toJSON()).toMatchSnapshot();
+});

--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -49,6 +49,13 @@ exports[`loading success 4`] = `
 </div>
 `;
 
+exports[`parallels 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"error":null}
+</div>
+`;
+
 exports[`preload 1`] = `
 <div>
   MyLoadingComponent 
@@ -105,14 +112,14 @@ exports[`server side rendering es6 1`] = `
 
 exports[`server side rendering flushing 1`] = `
 Array [
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component.js",
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component2.js",
+  "/Users/perrineboissieres/Workspace/react-loadable/__fixtures__/component.js",
+  "/Users/perrineboissieres/Workspace/react-loadable/__fixtures__/component2.js",
 ]
 `;
 
 exports[`server side rendering flushing 2`] = `
 Array [
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component.js",
-  "/Users/thejameskyle/Projects/react-loadable/__fixtures__/component3.js",
+  "/Users/perrineboissieres/Workspace/react-loadable/__fixtures__/component.js",
+  "/Users/perrineboissieres/Workspace/react-loadable/__fixtures__/component3.js",
 ]
 `;


### PR DESCRIPTION
This idea came when I ran into the necessity of loading localization files alongside chunks in a project.

You can use the new `parallels` option to send an array of promises to execute alongside the `import()`, and get the results in an `onLoaded` hook. The whole flow stays asynchronous.

```js
// example with fetch
const MyLoadable = Loadable({
  loader: () => import('MyComponent'),
  parallels: [
    () => fetch('path_to_resource').then(response => response.json()),
  ],
  onLoaded: ([module, data]) => {
    // store data, etc...
    // then we send the module so the flow can continue
    return Promise.resolve(module)
  },
})
```
