### PR TITLE
Provide props to LoadingComponent

### DIFF
--- a/__tests__/__snapshots__/Loadable.test.js.snap
+++ b/__tests__/__snapshots__/Loadable.test.js.snap
@@ -3,35 +3,35 @@
 exports[`loading error 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
 exports[`loading error 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
 exports[`loading error 3`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":false,"pastDelay":false,"error":{}}
+  {"prop":"baz","isLoading":false,"pastDelay":false,"error":{}}
 </div>
 `;
 
 exports[`loading success 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"foo","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
 exports[`loading success 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"error":null}
+  {"prop":"foo","isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 
@@ -52,7 +52,7 @@ exports[`loading success 4`] = `
 exports[`preload 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
@@ -73,14 +73,14 @@ exports[`preload 3`] = `
 exports[`resolveModule 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":false,"error":null}
 </div>
 `;
 
 exports[`resolveModule 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"error":null}
+  {"prop":"baz","isLoading":true,"pastDelay":true,"error":null}
 </div>
 `;
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import React from "react";
 
 type GenericComponent<Props> = Class<React.Component<{}, Props, mixed>>;
 type LoadedComponent<Props> = GenericComponent<Props>;
-type LoadingComponent = GenericComponent<{}>;
+type LoadingComponent<Props> = GenericComponent<Props>;
 
 let SERVER_SIDE_REQUIRE_PATHS = new Set();
 let WEBPACK_REQUIRE_WEAK_IDS = new Set();
@@ -26,7 +26,11 @@ let tryRequire = (resolveModuleFn: Function, pathOrId: string | number) => {
 
 type Options<Props> = {
   loader: () => Promise<LoadedComponent<Props>>,
-  LoadingComponent: LoadingComponent,
+  LoadingComponent: LoadingComponent<Props & {
+    isLoading: boolean,
+    error: ?Error,
+    postDelay: boolean
+  }>,
   delay?: number,
   serverSideRequirePath?: string,
   webpackRequireWeakId?: () => number,
@@ -140,6 +144,7 @@ export default function Loadable<Props: {}, Err: Error>(opts: Options<Props>) {
       if (isLoading || error) {
         return (
           <LoadingComponent
+            {...this.props}
             isLoading={isLoading}
             pastDelay={pastDelay}
             error={error}


### PR DESCRIPTION
Provides `props` passed to wrapped component to `LoadingComponent` too.

Use case:

```js
const Loader = ({
  error,
  isLoading,
  onClose,
  pastDelay,
}: {
  error: ?Error,
  isLoading: boolean,
  pastDelay: boolean,
}) => {
  if (isLoading) {
    return pastDelay
      ? <Modal closable onClose={onClose}>
          <Loading size="large" />
        </Modal>
      : null;
  } else if (error) {
    return <Modal closable onClose={onClose}>Error</Modal>;
  }
  return null;
};

const AddressModal = Loadable({
  loader: () => import('../AddressModal'),
  LoadingComponent: Loader,
});

<AddressModal onClose={this.handleClose} />
```