### PR TITLE
Error if loading option is not set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,10 @@ function render(loaded, props) {
 }
 
 function createLoadableComponent(loadFn, options) {
+  if (!options.loading) {
+    throw new Error('react-loadable requires a `loading` component')
+  }
+
   let opts = Object.assign({
     loader: null,
     loading: null,


### PR DESCRIPTION
If the `loading` option is not specified then react-loadable fatals with a cryptic React error. This makes the problem easier to discover.