### PR TITLE
Add support for default exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -228,4 +228,6 @@ function LoadableMap(opts) {
 
 Loadable.Map = LoadableMap;
 
+Loadable.default = Loadable;
+
 module.exports = Loadable;


### PR DESCRIPTION
When working with typescript `import Loadable from 'react-loadable';` is not working.
`import * as Loadable from 'react-loadable';` on the other hand works, but doesn't match the default Loadable-typings.

So adding a default export to support both `import Loadable from 'react-loadable';` and typings would be neat.