### PR TITLE
fixes async setState calls with ssr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ function createLoadableComponent(loadFn, options) {
     componentWillMount() {
       this._mounted = true;
 
-      if (res.resolved) {
+      if (!res.loading) {
         return;
       }
 


### PR DESCRIPTION
- Correctly checks whether component has already loaded or not in `componentWillMount`.

With SSR, `componentWillMount` was registering some `setTimeout` callbacks, calling `setState` asynchronously etc. This PR fixes it.

As far as I can see, `res.resolved` is never assigned to any value so it's always falsy. When `componentWillMount` is trigged; if `loading` is false, there's no point in doing the rest of the stuff. Because either `loaded` or `error` must be defined, so one of them can be rendered.

BTW, I have a suggestion for another PR: `loading` is a computable value: `loading === !loaded && !error`. So it makes sense to turn it into a computed value to reduce possible mistakes later on.