### PR TITLE
Refactored to use es6 modules, in order to expose a module build suit…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,21 @@
 {
-  "presets": [
-    ["es2015", {
-      "loose": true
-    }],
-    "react"
-  ]
+  "env": {
+    "cjs": {
+      "presets": [
+        ["es2015", {
+          "loose": true
+        }],
+        "react"
+      ]
+    },
+    "es": {
+      "presets": [
+        ["es2015", {
+          "loose": true,
+          "modules": false
+        }],
+        "react"
+      ]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 lib
+es

--- a/package.json
+++ b/package.json
@@ -3,15 +3,19 @@
   "version": "4.0.3",
   "description": "A higher order component for loading components with promises",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "author": "James Kyle <me@thejameskyle.com>",
   "license": "MIT",
   "repository": "thejameskyle/react-loadable",
   "files": [
-    "lib/**"
+    "lib/**",
+    "es/**"
   ],
   "scripts": {
-    "test": "jest",
-    "build": "babel src -d lib",
+    "test": "cross-env BABEL_ENV=cjs jest",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib",
+    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
+    "build": "npm run build:cjs && npm run build:es",
     "prepublish": "yarn run -s build"
   },
   "dependencies": {
@@ -23,6 +27,7 @@
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "cross-env": "^5.0.1",
     "flow-bin": "^0.41.0",
     "jest": "^19.0.2",
     "react": "^15.4.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-const React = require('react');
-const isWebpackBundle = require('is-webpack-bundle');
-const webpackRequireWeak = require('webpack-require-weak');
-const {inspect} = require('import-inspector');
+import React from 'react';
+import isWebpackBundle from 'is-webpack-bundle';
+import webpackRequireWeak from 'webpack-require-weak';
+import {inspect} from 'import-inspector';
 
 function capture(fn) {
   let reported = [];
@@ -218,7 +218,7 @@ function Loadable(opts) {
   return createLoadableComponent(load, opts);
 }
 
-function LoadableMap(opts) {
+export function LoadableMap(opts) {
   if (typeof opts.render !== 'function') {
     throw new Error('LoadableMap requires a `render(loaded, props)` function');
   }
@@ -226,6 +226,4 @@ function LoadableMap(opts) {
   return createLoadableComponent(loadMap, opts);
 }
 
-Loadable.Map = LoadableMap;
-
-module.exports = Loadable;
+export default Loadable;

--- a/test.js
+++ b/test.js
@@ -3,7 +3,8 @@
 const path = require('path');
 const React = require('react');
 const renderer = require('react-test-renderer');
-const Loadable = require('./src');
+const Loadable = require('./src').default;
+const LoadableMap = require('./src').LoadableMap;
 const {report} = require('import-inspector');
 
 function waitFor(delay) {
@@ -147,7 +148,7 @@ test('render', async () => {
 });
 
 test('loadable map success', async () => {
-  let LoadableMyComponent = Loadable.Map({
+  let LoadableMyComponent = LoadableMap({
     loader: {
       a: createLoader(200, { MyComponent }),
       b: createLoader(400, { MyComponent }),
@@ -172,7 +173,7 @@ test('loadable map success', async () => {
 });
 
 test('loadable map error', async () => {
-  let LoadableMyComponent = Loadable.Map({
+  let LoadableMyComponent = LoadableMap({
     loader: {
       a: createLoader(200, { MyComponent }),
       b: createLoader(400, null, new Error('test error')),

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,6 +869,21 @@ create-react-class@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+cross-env@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.1.tgz#ff4e72ea43b47da2486b43a7f2043b2609e44913"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1407,6 +1422,10 @@ is-webpack-bundle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-webpack-bundle/-/is-webpack-bundle-1.0.0.tgz#576a50bb7c53d1d6a5c1647939c93ae2cbb90eea"
 
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
+
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1839,6 +1858,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   dependencies:
     js-tokens "^3.0.0"
 
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -2162,6 +2188,10 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -2390,6 +2420,16 @@ set-immediate-shim@^1.0.1:
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shellwords@^0.1.0:
   version "0.1.0"
@@ -2691,7 +2731,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.1.1, which@^1.2.12:
+which@^1.1.1, which@^1.2.12, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -2748,6 +2788,10 @@ xml-name-validator@^2.0.1:
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
…able for es module aware bundlers like webpack2+ and rollup - enabling them to perform tree-shaking on unused exports.

This is ofc just a proposal and a **breaking change** (due to es6 modules usage).

Note: this would also allow webpack3+ to perform scope hoisting on this library as it will stop being treated as commonjs module.