### PR TITLE
Fix undefined `error` being set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ function loadMap(obj) {
       });
     });
   } catch (err) {
-    error = err;
+    state.error = err;
   }
 
   state.promise = Promise.all(promises).then(res => {


### PR DESCRIPTION
The `error` variable is undefined here, so this attempt to assign `err`
to it results in a `ReferenceError`. From the rest of the code, it looks
like this should have been `state.error`.