### PR TITLE
Expose promise to react tree for monitoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,9 @@ function createLoadableComponent(loadFn, options) {
       if (!res) {
         res = loadFn(opts.loader);
       }
-
+      // placing promise outside of state as it does not have to be monitored for changes
+      // and triggersx updates in other ways.
+      this.promise = res.promise
       this.state = {
         error: res.error,
         pastDelay: false,
@@ -203,7 +205,8 @@ function createLoadableComponent(loadFn, options) {
           isLoading: this.state.loading,
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
-          error: this.state.error
+          error: this.state.error,
+          promise: this.promise
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);


### PR DESCRIPTION
This makes it possible to use it as a hook in testing. 

I was thinking about adding a component that is exported so that it would be easy to do a enzyme.find(Component), but thought I'd start with the smallest possible change.

