### PR TITLE
when webpackRequireWeakId is true, set loading to false only if module exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,8 @@ function load(loader) {
   try {
     if (isWebpackBundle) {
       if (typeof metadata.webpackRequireWeakId === 'function') {
-        state.loading = false;
         state.loaded = webpackRequireWeak(metadata.webpackRequireWeakId());
+        if (state.loaded) state.loading = false;
       }
     } else {
       if (typeof metadata.serverSideRequirePath === 'string') {


### PR DESCRIPTION
Because the webpackRequireWeakId is a global setting for all the dynamic imports, setting it to true disables the loading component for all the imports even if only few of them were served with the initial request and only for them there is no need to show the loading component.
All the loaded by request components should show the loading component until the chunk is loaded.

In my SPA scenario, I'm serving the chunk of the current page (with all the common chunks) on the initial request of that page. This chunk shouldn't show the loading component because its already exist. When going to other pages, which dynamically loads other chunks, there is need to show the loading component.

This PR fixes this behavior and shows the loading component of dynamically loaded chunks even if the webpackRequireWeakId is set to true.