### PR TITLE
Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ Rendering server-side should then just work.
 ### Sync rendering preloaded imports in Webpack
 
 See [`babel-plugin-import-inspector`](#babel-plugin-import-inspector) and make
-sure to set `serverSideRequirePath` to `true`.
+sure to set `webpackRequireWeakId` to `true`.
 
 ```js
 {
   "plugins": [
     ["import-inspector", {
-      "serverSideRequirePath": true,
+      "webpackRequireWeakId": true,
     }]
   ]
 }


### PR DESCRIPTION
The webpack block had been copied from the server-side rendering block without the corresponding bits updated. I think this fixes it.