### PR TITLE
Always import when using webpack server-side

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ const isWebpackBundle = require('is-webpack-bundle');
 const webpackRequireWeak = require('webpack-require-weak');
 const {inspect} = require('import-inspector');
 
+function isNode() {
+  return !!(typeof process !== 'undefined' && process.versions && process.versions.node);
+}
+
 function capture(fn) {
   let reported = [];
   let stopInspecting = inspect(metadata => reported.push(metadata));
@@ -127,7 +131,7 @@ function createLoadableComponent(loadFn, options) {
     constructor(props) {
       super(props);
 
-      if (!res) {
+      if (!res || (isNode() && isWebpackBundle)) {
         res = loadFn(opts.loader);
       }
 


### PR DESCRIPTION
When using webpack to transpile server code we use webpack weak Ids to resolve dynamic imports.

Server will cache these imports so the second time a module is required it will not be reported by the import inspector.

This change ensure that these imports are always reported when running server code transpiled by webpack.