### PR TITLE
Prevent running timers on mounting if component is already loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ function createLoadableComponent(loadFn, options) {
     componentWillMount() {
       this._mounted = true;
 
-      if (res.resolved) {
+      if (res.loaded) {
         return;
       }
 


### PR DESCRIPTION
It seems that `resolved` prop is present only [once](https://github.com/thejameskyle/react-loadable/blob/4be1b7b03d27a1fa9b2e02814a2d8c905668bede/src/index.js#L152) in entire file, and never is set or updated. Looks like it should be `res.loaded`, so no timers and no extra state updates will happen on successive mountings.