### PR TITLE
create output directory if not exists

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -29,8 +29,12 @@ class ReactLoadablePlugin {
       const manifest = buildManifest(compiler, compilation);
       var json = JSON.stringify(manifest, null, 2);
       const outputDirectory = path.dirname(this.filename);
-      if (!fs.existsSync(outputDirectory)) {
+      try {
         fs.mkdirSync(outputDirectory);
+      } catch (err) {
+        if (err.code !== 'EEXIST') {
+          throw err;
+        }
       }
       fs.writeFileSync(this.filename, json);
       callback();

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const path = require('path');
 
 function buildManifest(compiler, compilation) {
   let context = compiler.options.context;
@@ -27,6 +28,10 @@ class ReactLoadablePlugin {
     compiler.plugin('emit', (compilation, callback) => {
       const manifest = buildManifest(compiler, compilation);
       var json = JSON.stringify(manifest, null, 2);
+      const outputDirectory = path.dirname(this.filename);
+      if (!fs.existsSync(outputDirectory)) {
+        fs.mkdirSync(outputDirectory);
+      }
       fs.writeFileSync(this.filename, json);
       callback();
     });


### PR DESCRIPTION
Hi, I did a fresh clone and was trying to run the example, I got this error
```
λ yarn start
yarn run v1.1.0
$ yarn build && webpack && babel-node example/server.js
src/babel.js -> lib/babel.js
src/index.js -> lib/index.js
src/webpack.js -> lib/webpack.js
fs.js:652
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/Users/tls/Projects/react-loadable/example/dist/react-loadable.json'
    at Object.fs.openSync (fs.js:652:18)
    at Object.fs.writeFileSync (fs.js:1299:33)
    at Compiler.<anonymous> (/Users/tls/Projects/react-loadable/lib/webpack.js:41:10)
    at Compiler.applyPluginsAsyncSeries (/Users/tls/Projects/react-loadable/node_modules/tapable/lib/Tapable.js:206:13)
```

This happens for the first time when the `dist` directory does not exist, This PR adds the check and creates the directory if not exist.

Is it okay if we include this in `react-loadable/webpack` plugin or is it something `webpack` should handle?