### PR TITLE
Delay 0 should show loading state in the current event loop

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -146,6 +146,13 @@ exports[`preload 3`] = `
 </div>
 `;
 
+exports[`preloadReady delay with 0 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+</div>
+`;
+
 exports[`preloadReady many 1`] = `
 <div>
   MyComponent 

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -264,4 +264,17 @@ describe('preloadReady', () => {
 
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  test('delay with 0', () => {
+    let LoadableMyComponent = Loadable({
+      loader: createLoader(300, () => MyComponent),
+      loading: MyLoadingComponent,
+      delay: 0,
+      timeout: 200,
+    });
+  
+    let loadingComponent = renderer.create(<LoadableMyComponent prop="foo" />);
+  
+    expect(loadingComponent.toJSON()).toMatchSnapshot(); // loading
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -163,9 +163,13 @@ function createLoadableComponent(loadFn, options) {
       }
 
       if (typeof opts.delay === 'number') {
-        this._delay = setTimeout(() => {
+        if (opts.delay === 0) {
           this.setState({ pastDelay: true });
-        }, opts.delay);
+        } else {
+          this._delay = setTimeout(() => {
+            this.setState({ pastDelay: true });
+          }, opts.delay);
+        }
       }
 
       if (typeof opts.timeout === 'number') {


### PR DESCRIPTION
When delay is set to 0, loading state should show up immediately. Currently showing the loading state is delayed until the next event loop due to setTimeout. 