### PR TITLE
Extract js & css files for manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,16 +550,24 @@ We can then render these bundles into `<script>` tags in our HTML.
 
 ```js
 let bundles = getBundles(stats, modules);
+/*
+  [{ id, name, js, css}]
+*/
 
 res.send(`
   <!doctype html>
   <html lang="en">
-    <head>...</head>
+    <head>
+    ...
+    ${bundles.map(bundle => {
+      return `<link href="/dist/${bundle.css}" rel="stylesheet"/>`
+    }).join('\n')}
+    </head>
     <body>
       <div id="app">${html}</div>
       <script src="/dist/main.js"></script>
       ${bundles.map(bundle => {
-        return `<script src="/dist/${bundle.file}"></script>`
+        return `<script src="/dist/${bundle.js}"></script>`
       }).join('\n')}
     </body>
   </html>

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,6 +1,6 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
+"use strict";
+const fs = require("fs");
+const path = require("path");
 
 function buildManifest(compiler, compilation) {
   let context = compiler.options.context;
@@ -10,8 +10,23 @@ function buildManifest(compiler, compilation) {
     chunk.files.forEach(file => {
       chunk.forEachModule(module => {
         let id = module.id;
-        let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
-        manifest[module.rawRequest] = { id, name, file };
+        let name =
+          typeof module.libIdent === "function"
+            ? module.libIdent({ context })
+            : null;
+        const filenames = {};
+        if (isJs(file)) {
+          filename.js = file;
+        }
+        if (isCss(file)) {
+          filename.css = file;
+        }
+        manifest[module.rawRequest] = {
+          ...manifest[module.rawRequest],
+          id,
+          name,
+          ...filenames
+        };
       });
     });
   });
@@ -25,14 +40,14 @@ class ReactLoadablePlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
+    compiler.plugin("emit", (compilation, callback) => {
       const manifest = buildManifest(compiler, compilation);
       var json = JSON.stringify(manifest, null, 2);
       const outputDirectory = path.dirname(this.filename);
       try {
         fs.mkdirSync(outputDirectory);
       } catch (err) {
-        if (err.code !== 'EEXIST') {
+        if (err.code !== "EEXIST") {
           throw err;
         }
       }


### PR DESCRIPTION
Webpack will emit 4 files with the same 'rawname' if you have sourcemaps & also chunking css: [file].js [file].js.map [cssfile].css [cssfile].css.map.

This would allow us to exclude maps and also get the css files