### PR TITLE
Depend on prop-types the way Facebook recommends

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "start": "yarn build && webpack && babel-node example/server.js",
     "prepublish": "yarn build"
   },
+  "dependencies": {
+    "prop-types": "^15.5.7"
+  },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-loader": "^7.1.2",
@@ -35,7 +38,6 @@
     "webpack": "^3.6.0"
   },
   "peerDependencies": {
-    "react": "*",
-    "prop-types": "*"
+    "react": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "prop-types": "^15.5.7"
+    "prop-types": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3066,7 +3066,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.5.7, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:


### PR DESCRIPTION
https://github.com/facebook/prop-types#how-to-depend-on-this-package

> For libraries, we *also* recommend leaving it in `dependencies`:
>
> ```js
>   "dependencies": {
>     "prop-types": "^15.5.7"
>   },
>   "peerDependencies": {
>     "react": "^15.5.0"
>   }
> ```
>
> **Note:** there are known issues in versions before 15.5.7 so we
> recommend using it as the minimal version.
>
> Make sure that the version range uses a caret (`^`) and thus is broad
> enough for npm to efficiently deduplicate packages.

---

Motivation:

- react-loadable currently has prop-types as a peer dependency.
- My project uses react-loadable but not prop-types.
- When installing dependencies, `yarn` correctly gives this warning:

```
warning "react-loadable@5.3.0" has incorrect peer dependency "prop-types@*".
```

Today I finally felt like doing something about that warning. There are two ways I can go:

1. Add prop-types to my project dependencies, and document that we only install it as a peer dependency for react-loadable.

2. This PR :)

(My project works even though I haven’t explicitly installed prop-types because other React libraries happen to depend on it ;) )