### PR TITLE
Fix for unhandled promise rejections in Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-preset-react": "^6.24.1",
     "express": "^4.16.1",
     "flow-bin": "^0.41.0",
-    "jest": "^19.0.2",
+    "jest": "^21.2.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,6 @@ function createLoadableComponent(loadFn, options) {
         update();
       }).catch(err => {
         update();
-        throw err;
       });
     }
 


### PR DESCRIPTION
Firstly, thanks for this library.

Since [Jest v21.0.0](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-2100), there is an [`unhandledRejection` handler](https://github.com/facebook/jest/pull/4016) that will fail tests that don't handle promise rejections.

`Loadable` leaves an unhandled promise rejection when the `loader` promise is rejected and consequently the test fails.  This makes cases where the error case is expected impossible to test.

This change stops throwing `err` in the `catch` of the promise, so the promise rejection is handled. 
 I believe this is not an issue as the promise is not returned and therefore cannot be chained onto, making the rejection unnecessary in the first place.