### PR TITLE
Transforming Object.assign() with Babel (fix IE11 issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-module-resolver": "^2.7.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "express": "^4.16.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = {
             plugins: [
               'syntax-dynamic-import',
               'transform-class-properties',
+              'transform-object-assign',
               require.resolve('./babel'),
             ],
           }


### PR DESCRIPTION
Thanks a lot for this awesome library!

We detected an issue on IE11, as Babel does not include the polyfill for `Object.assign()` in its es2015 preset. You need to include yourself the plugin to transform it, so here it is ^^