### PR TITLE
Fix bundle filters to match documentation

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -19,8 +19,8 @@ app.get('/', (req, res) => {
 
   let bundles = getBundles(stats, modules);
 
-  let styles = bundles.filter(bundle => bundle.endsWith('.css'));
-  let scripts = bundles.filter(bundle => bundle.endsWith('.js'));
+  let styles = bundles.filter(bundle => bundle.file.endsWith('.css'));
+  let scripts = bundles.filter(bundle => bundle.file.endsWith('.js'));
 
   res.send(`
     <!doctype html>


### PR DESCRIPTION
Currently, the server side rendering example results in the following error:
```
TypeError: bundle.endsWith is not a function
```
This pull request updates the bundle filtering to match the provided documentation. 