### PR TITLE
compatibility with ConcatenatedModule

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -13,12 +13,16 @@ function buildManifest(compiler, compilation) {
         let id = module.id;
         let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
         let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
-
-        if (!manifest[module.rawRequest]) {
-          manifest[module.rawRequest] = [];
+        
+        let currentModule = module;
+        if (module.constructor.name === 'ConcatenatedModule') {
+          currentModule = module.rootModule;
+        }
+        if (!manifest[currentModule.rawRequest]) {
+          manifest[currentModule.rawRequest] = [];
         }
 
-        manifest[module.rawRequest].push({ id, name, file, publicPath });
+        manifest[currentModule.rawRequest].push({ id, name, file, publicPath });
       });
     });
   });


### PR DESCRIPTION
when using `webpack.optimize.ModuleConcatenationPlugin` some modules are instances of `ConcatenatedModule` which have no `rawRequest` property, which breaks the manifest.
I tried this change with the example in the repo and it worked fine.